### PR TITLE
Upgrade mason dep versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,11 @@ if (ENABLE_MASON)
     set(MASON_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/.mason/mason)
     include(${CMAKE_CURRENT_SOURCE_DIR}/.mason/mason.cmake)
 
-    mason_use(libosmium VERSION 2.10.3 HEADER_ONLY)
+    mason_use(libosmium VERSION 2.12.0 HEADER_ONLY)
     include_directories(${MASON_PACKAGE_libosmium_INCLUDE_DIRS})
     set(OSMIUM_INCLUDE_DIRS ${MASON_PACKAGE_libosmium_INCLUDE_DIRS})
 
-    mason_use(protozero VERSION 1.4.2 HEADER_ONLY)
+    mason_use(protozero VERSION 1.5.1 HEADER_ONLY)
     include_directories(${MASON_PACKAGE_protozero_INCLUDE_DIRS})
     set(PROTOZERO_INCLUDE_DIRS ${MASON_PACKAGE_protozero_INCLUDE_DIRS})
 
@@ -26,9 +26,9 @@ if (ENABLE_MASON)
     include_directories(${MASON_PACKAGE_bzip2_INCLUDE_DIRS})
     set(BZIP2_LIBRARIES ${MASON_PACKAGE_bzip2_STATIC_LIBS})
 
-    # use system zlib, mason zlib does not work with libosmium
-    find_package(ZLIB REQUIRED)
-    include_directories(${ZLIB_INCLUDE_DIRS})
+    mason_use(zlib VERSION 1.2.8)
+    include_directories(${MASON_PACKAGE_zlib_INCLUDE_DIRS})
+    set(ZLIB_LIBRARY ${MASON_PACKAGE_zlib_STATIC_LIBS})
 
     add_executable(${PROJECT_NAME} main.cc)
     target_link_libraries(${PROJECT_NAME} ${OSMIUM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARY} ${EXPAT_LIBRARIES} ${BZIP2_LIBRARIES})


### PR DESCRIPTION
This pulls in the latest libosmium and protozero. It also attempts to use the zlib package, since this should now be working via mason.