### PR TITLE
Do not rewrite on any namespaced destination tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 third_party
+*_rewritten.osm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,24 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev']
+          packages: ['g++-7', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev', 'libboost-all-dev']
+      env: CCOMPILER='gcc-7' CXXCOMPILER='g++-7'
+
+    - os: linux
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev', 'libboost-all-dev']
       env: CCOMPILER='gcc-6' CXXCOMPILER='g++-6'
 
     - os: linux
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev']
+          packages: ['g++-5', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev', 'libboost-all-dev']
       env: CCOMPILER='gcc-5' CXXCOMPILER='g++-5'
 
-    - os: linux
-      addons:
-        apt:
-          sources: ['llvm-toolchain-precise-3.8']
-          packages: ['clang-3.8', 'cmake', 'realpath', 'libbz2-dev', 'zlib1g-dev', 'libexpat1-dev']
-      env: CCOMPILER='clang-3.8' CXXCOMPILER='clang++-3.8'
-
-    # Waiting on Travis whitelisting 3.9, see https://github.com/travis-ci/apt-source-whitelist/issues/300
+    # Waiting on Travis whitelisting clang-4.0
 
 
 before_install:

--- a/deps.sh
+++ b/deps.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly LIBOSMIUM_URL="https://github.com/osmcode/libosmium/archive/v2.10.3.tar.gz"
+readonly LIBOSMIUM_URL="https://github.com/osmcode/libosmium/archive/v2.12.2.tar.gz"
 readonly LIBOSMIUM_DIR="libosmium"
 
 mkdir -p third_party/${LIBOSMIUM_DIR}

--- a/tests/negative/138_destination_ref_tag_already_present.osm
+++ b/tests/negative/138_destination_ref_tag_already_present.osm
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="osrm-test" version="0.6">
+  <node id="1" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0" lat="1.0">
+    <tag k="name" v="a"/>
+  </node>
+  <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
+    <tag k="name" v="b"/>
+    <tag k="highway" v="motorway_junction"/>
+    <tag k="exit_to" v="ExitC"/>
+  </node>
+  <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
+    <tag k="name" v="d"/>
+  </node>
+  <node id="4" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="0.999820186412746">
+    <tag k="name" v="c"/>
+  </node>
+  <way id="5" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="motorway"/>
+    <tag k="oneway" v=""/>
+    <tag k="destination:ref" v=""/>
+    <tag k="name" v="abd"/>
+  </way>
+  <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
+    <nd ref="2"/>
+    <nd ref="4"/>
+    <tag k="highway" v="motorway_link"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="destination:ref" v="DestinationC"/>
+    <tag k="name" v="bc"/>
+  </way>
+</osm>

--- a/tests/rewrite.feature
+++ b/tests/rewrite.feature
@@ -134,3 +134,23 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
        When I route I should get
             | waypoints | route    |
             | a,c       | ab,bc,bc |
+
+    Scenario: Destination ref tag already present
+        Given the node map
+            """
+            a . . . b . . d .
+                      ` . c .
+            """
+
+       And the nodes
+            | node | highway           | exit_to |
+            | b    | motorway_junction | ExitC   |
+
+        And the ways
+            | nodes | highway       | oneway | destination:ref |
+            | abd   | motorway      |        |                 |
+            | bc    | motorway_link | yes    | DestinationC    |
+
+       When I route I should get
+            | waypoints | route    |
+            | a,c       | ab,bc,bc |


### PR DESCRIPTION
Currently we do not re-write `exit_to` tags when there is a `destination` tag present on ways.

This changeset makes the check even more conservative: we no longer re-write if there is any `destination*` tag present. Which includes `destination:ref`, `destination:street` or any other namespaced destination tag.

The reason for doing so is it's highly likely that the destination information is already present in the namespaced destination tag and we want to be conservative in these cases.

Ref. https://github.com/osmcode/libosmium/issues/210