### PR TITLE
Implements exit number rewriter, resolves #7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.11)
-project(exit2destination LANGUAGES C CXX)
+project(osrm-tag-rewriter LANGUAGES C CXX)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,12 @@ if (ENABLE_MASON)
     include_directories(${MASON_PACKAGE_zlib_INCLUDE_DIRS})
     set(ZLIB_LIBRARY ${MASON_PACKAGE_zlib_STATIC_LIBS})
 
-    add_executable(${PROJECT_NAME} main.cc)
+    add_executable(${PROJECT_NAME} src/main.cc)
+    target_include_directories(${PROJECT_NAME} PRIVATE src)
     target_link_libraries(${PROJECT_NAME} ${OSMIUM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARY} ${EXPAT_LIBRARIES} ${BZIP2_LIBRARIES})
     target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${OSMIUM_INCLUDE_DIRS} ${UTFCPP_INCLUDE_DIRS} ${BOOST_INCLUDE_DIRS})
 else()
-    # expects a vendored libosmium at /third_party
+    # expects a vendored libosmium at /third_party (invoke ./deps.sh)
     # explicit inclusion of protozero and zlib dependencies are not required
     # if libosmium is vendored. The find_package(Osmium) call calls libosmium's
     # cmake files that find required dependencies in the system
@@ -50,7 +51,8 @@ else()
     set(OSMIUM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libosmium/include")
     find_package(Osmium REQUIRED COMPONENTS pbf xml)
 
-    add_executable(${PROJECT_NAME} main.cc)
+    add_executable(${PROJECT_NAME} src/main.cc)
+    target_include_directories(${PROJECT_NAME} PRIVATE src)
     target_link_libraries(${PROJECT_NAME} ${OSMIUM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${OSMIUM_INCLUDE_DIRS})
 endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Mapbox
+Copyright (c) 2017 Mapbox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Rewrites OpenStreetMap tags for example from motorway junction nodes to its ramps.
 Mainly for easier handling in our [routing engine](https://github.com/Project-OSRM/osrm-backend#open-source-routing-machine).
 
-[![Continuous Integration](https://travis-ci.org/mapbox/rewrite-exit-destination-signage.svg?branch=master)](https://travis-ci.org/mapbox/rewrite-exit-destination-signage)
+[![Continuous Integration](https://travis-ci.org/mapbox/osrm-tag-rewriter.svg?branch=master)](https://travis-ci.org/mapbox/osrm-tag-rewriter)
 
 
 ## Building
@@ -45,6 +45,13 @@ Rewrites OpenStreetMap [`exit_to=`](http://wiki.openstreetmap.org/wiki/Key:exit_
 
 - Query for `exit_to` node tags, Bay Area: http://overpass-turbo.eu/s/kEM
 - Query for `destination` way tags, Bay Area: http://overpass-turbo.eu/s/kEN
+
+
+### Exit Numbers
+
+Rewrites OpenStreetMap [`ref=`](http://wiki.openstreetmap.org/wiki/Key:ref) Node tags on [`highway=motorway_junction`](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_junction) to [`junction:ref=`](http://wiki.openstreetmap.org/wiki/Proposed_features/junction_details) tags on the adjacent way when possible to do so without ambiguity.
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-## `exit_to=` to `destination=`
+## osrm-tag-rewriter
+
+Rewrites OpenStreetMap tags for example from motorway junction nodes to its ramps.
+Mainly for easier handling in our [routing engine](https://github.com/Project-OSRM/osrm-backend#open-source-routing-machine).
 
 [![Continuous Integration](https://travis-ci.org/mapbox/rewrite-exit-destination-signage.svg?branch=master)](https://travis-ci.org/mapbox/rewrite-exit-destination-signage)
 
-Rewrites OpenStreetMap [`exit_to=`](http://wiki.openstreetmap.org/wiki/Key:exit_to) Node tags on [`highway=motorway_junction`](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_junction) to [`destination=`](http://wiki.openstreetmap.org/wiki/Key:destination) tags on the adjacent way when possible to do so without ambiguity.
-
-### Why
-
-- Query for `exit_to` node tags, Bay Area: http://overpass-turbo.eu/s/kEM
-- Query for `destination` way tags, Bay Area: http://overpass-turbo.eu/s/kEN
 
 ## Building
 
@@ -29,7 +26,7 @@ You can build this project using packages bundled with mason:
 
 ## Running
 
-    ./exit2destination in.osm.pbf out.osm.pbf
+    ./osrm-tag-rewriter in.osm.pbf out.osm.pbf
 
 ## Tests
 
@@ -39,8 +36,18 @@ See the `tests` directory.
     ./check.sh
     popd
 
+
+## Rewriters
+
+### Destination Tags
+
+Rewrites OpenStreetMap [`exit_to=`](http://wiki.openstreetmap.org/wiki/Key:exit_to) Node tags on [`highway=motorway_junction`](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_junction) to [`destination=`](http://wiki.openstreetmap.org/wiki/Key:destination) tags on the adjacent way when possible to do so without ambiguity.
+
+- Query for `exit_to` node tags, Bay Area: http://overpass-turbo.eu/s/kEM
+- Query for `destination` way tags, Bay Area: http://overpass-turbo.eu/s/kEN
+
 ## License
 
-Copyright © 2016 Mapbox
+Copyright © 2017 Mapbox
 
 Distributed under the MIT License (MIT).

--- a/src/exits.h
+++ b/src/exits.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cstdlib>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <osmium/builder/osm_object_builder.hpp>
+#include <osmium/handler.hpp>
+#include <osmium/osm/types.hpp>
+
+#include "util.h"
+
+// Collects node ids and ref=* tags on highway=motorway_junction.
+// http://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_junction
+// http://taginfo.openstreetmap.org/keys/exit_to
+// http://wiki.openstreetmap.org/wiki/Proposed_features/junction_details
+struct ExitsRewriter : osmium::handler::Handler {
+  static const constexpr auto kRefsOnJunctionInPlanet = 91000u;
+  static const constexpr auto kBufferCapacityHint = 1u << 12u;
+
+  ExitsRewriter() { exits.reserve(kRefsOnJunctionInPlanet); }
+
+  void node(const osmium::Node &node) {
+    Committer defer{outbuf};
+
+    // Copy over node data untouched
+    outbuf.add_item(node);
+
+    // Record ref node ids and values
+    const auto *highway = node.get_value_by_key("highway");
+
+    if (!highway || !Equal("motorway_junction", highway))
+      return;
+
+    const auto *ref = node.get_value_by_key("ref");
+
+    if (ref)
+      exits.insert({node.positive_id(), std::string{ref}});
+  }
+
+  void way(const osmium::Way &way) {
+    const auto &nodes = way.nodes();
+
+    const auto *highway = way.get_value_by_key("highway");
+
+    // http://wiki.openstreetmap.org/wiki/Key:highway#Link_roads
+    const auto isLink = highway && (Equal("motorway_link", highway)      //
+                                    || Equal("trunk_link", highway)      //
+                                    || Equal("primary_link", highway)    //
+                                    || Equal("secondary_link", highway)  //
+                                    || Equal("tertiary_link", highway)); //
+
+    const auto *oneway = way.get_value_by_key("oneway");
+    const auto isOneway = oneway && (Equal("yes", oneway) ||  //
+                                     Equal("1", oneway) ||    //
+                                     Equal("true", oneway) || //
+                                     Equal("-1", oneway));    //
+
+    const auto isReversed = isOneway && Equal("-1", oneway);
+    const auto startNode = isReversed ? nodes.back().positive_ref() : nodes.front().positive_ref();
+
+    // Do not re-write if there is a "junction:ref" tag already present
+    const auto hasJunctionRef = way.get_value_by_key("junction:ref") != nullptr;
+
+    Committer defer{outbuf};
+
+    // Copy over way attributes untouched
+    osmium::builder::WayBuilder builder{outbuf};
+    Copy(builder, way);
+
+    if (isLink && isOneway && !hasJunctionRef) {
+      const auto it = exits.find(startNode);
+
+      if (it != end(exits)) {
+        Extend(builder, way.tags(), "junction:ref", it->second.c_str());
+        added += 1;
+      } else {
+        builder.add_item(way.tags());
+      }
+    } else {
+      builder.add_item(way.tags());
+    }
+
+    // Copy over way nodes untouched
+    builder.add_item(way.nodes());
+  }
+
+  void relation(const osmium::Relation &relation) {
+    Committer defer{outbuf};
+
+    // Copy over relation data untouched
+    outbuf.add_item(relation);
+  }
+
+  // We write and committ into a buffer; let the user grab the full buffer.
+  // Switch in an empty one for the next handler application.
+  osmium::memory::Buffer buffer() {
+    osmium::memory::Buffer tmp{kBufferCapacityHint};
+
+    using std::swap;
+    swap(tmp, outbuf);
+
+    return tmp;
+  }
+
+  // Number of destination way tags added.
+  std::size_t added = 0;
+
+private:
+  osmium::memory::Buffer outbuf{kBufferCapacityHint};
+
+  using NodeId = osmium::unsigned_object_id_type;
+  using Value = std::string;
+
+  std::unordered_map<NodeId, Value> exits;
+};

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+
+#include <string>
+#include <utility>
+
+#include <osmium/builder/osm_object_builder.hpp>
+#include <osmium/osm/types.hpp>
+#include <osmium/tags/taglist.hpp>
+
+inline bool Equal(const char *lhs, const char *rhs) { return std::strcmp(lhs, rhs) == 0; }
+
+struct Committer {
+  osmium::memory::Buffer &buffer;
+  ~Committer() noexcept { buffer.commit(); }
+};
+
+template <typename Builder> //
+inline void Copy(Builder &builder, const osmium::OSMObject &object) {
+  builder.set_id(object.id())
+      .set_version(object.version())
+      .set_changeset(object.changeset())
+      .set_timestamp(object.timestamp())
+      .set_uid(object.uid())
+      .set_user(object.user());
+}
+
+inline void Extend(osmium::builder::Builder &parent, const osmium::TagList &tags, const char *key, const char *value) {
+  osmium::builder::TagListBuilder builder{parent};
+
+  for (const auto &tag : tags)
+    builder.add_tag(tag);
+
+  builder.add_tag(key, value);
+}

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -4,16 +4,14 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly bin=$(realpath ${1:-../build/exit2destination})
+readonly rewrite=$(realpath ${1:-../build/osrm-tag-rewriter})
 
-for osm in positive/*.osm
-do
-	code=$(${bin} ${osm} ${osm%.*}_rewritten.osm | egrep --only-matching '[[:digit:]]')
-	if [ ${code} -lt 1 ]; then echo "Error: ${osm}"; exit 1; fi
-done
+${rewrite} positive/8_successful_rewrite.osm positive/8_successful_rewrite_rewritten.osm
+${rewrite} positive/157_reversed_way.osm positive/157_reversed_way_rewritten.osm
 
-for osm in negative/*.osm
-do
-	code=$(${bin} ${osm} ${osm%.*}_rewritten.osm | egrep --only-matching '[[:digit:]]')
-	if [ ${code} -gt 0 ]; then echo "Error: ${osm}"; exit 1; fi
-done
+${rewrite} negative/29_left_and_right_exits_not_supported_only_a_few_hundred_left_right.osm negative/29_left_and_right_exits_not_supported_only_a_few_hundred_left_right_rewritten.osm
+${rewrite} negative/52_not_a_motorway_junction_node.osm negative/52_not_a_motorway_junction_node_rewritten.osm
+${rewrite} negative/73_not_a_link_road.osm negative/73_not_a_link_road_rewritten.osm
+${rewrite} negative/94_not_a_oneway_link.osm negative/94_not_a_oneway_link_rewritten.osm
+${rewrite} negative/115_tag_already_present.osm negative/115_tag_already_present_rewritten.osm
+${rewrite} negative/136_ref_tag_already_present.osm negative/136_ref_tag_already_present_rewritten.osm

--- a/tests/negative/115_tag_already_present.osm
+++ b/tests/negative/115_tag_already_present.osm
@@ -6,7 +6,8 @@
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
     <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -20,6 +21,8 @@
     <nd ref="3"/>
     <tag k="highway" v="motorway"/>
     <tag k="oneway" v=""/>
+    <tag k="destination" v=""/>
+    <tag k="junction:ref" v=""/>
     <tag k="name" v="abd"/>
   </way>
   <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
@@ -27,6 +30,8 @@
     <nd ref="4"/>
     <tag k="highway" v="motorway_link"/>
     <tag k="oneway" v="yes"/>
+    <tag k="destination" v="B"/>
+    <tag k="junction:ref" v="2"/>
     <tag k="name" v="bc"/>
   </way>
 </osm>

--- a/tests/negative/136_ref_tag_already_present.osm
+++ b/tests/negative/136_ref_tag_already_present.osm
@@ -6,7 +6,8 @@
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
     <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -20,13 +21,17 @@
     <nd ref="3"/>
     <tag k="highway" v="motorway"/>
     <tag k="oneway" v=""/>
+    <tag k="destination:ref" v=""/>
+    <tag k="junction:ref" v=""/>
     <tag k="name" v="abd"/>
   </way>
   <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
     <nd ref="2"/>
     <nd ref="4"/>
     <tag k="highway" v="motorway_link"/>
-    <tag k="oneway" v="no"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="destination:ref" v="B"/>
+    <tag k="junction:ref" v="3"/>
     <tag k="name" v="bc"/>
   </way>
 </osm>

--- a/tests/negative/29_left_and_right_exits_not_supported_only_a_few_hundred_left_right.osm
+++ b/tests/negative/29_left_and_right_exits_not_supported_only_a_few_hundred_left_right.osm
@@ -9,8 +9,10 @@
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="0.999820186412746">
     <tag k="name" v="b"/>
     <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to:left" v="ExitC"/>
-    <tag k="exit_to:right" v="ExitD"/>
+    <tag k="exit_to:left" v="A"/>
+    <tag k="exit_to:right" v="B"/>
+    <tag k="ref:left" v="2"/>
+    <tag k="ref:right" v="3"/>
   </node>
   <node id="4" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="0.9996403728254918">
     <tag k="name" v="c"/>

--- a/tests/negative/52_not_a_motorway_junction_node.osm
+++ b/tests/negative/52_not_a_motorway_junction_node.osm
@@ -5,8 +5,9 @@
   </node>
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
-    <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="highway" v=""/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -25,7 +26,7 @@
   <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
     <nd ref="2"/>
     <nd ref="4"/>
-    <tag k="highway" v="motorway"/>
+    <tag k="highway" v="motorway_link"/>
     <tag k="oneway" v="yes"/>
     <tag k="name" v="bc"/>
   </way>

--- a/tests/negative/73_not_a_link_road.osm
+++ b/tests/negative/73_not_a_link_road.osm
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="osrm-test" version="0.6">
+  <node id="1" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0" lat="1.0">
+    <tag k="name" v="a"/>
+  </node>
+  <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
+    <tag k="name" v="b"/>
+    <tag k="highway" v="motorway_junction"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
+  </node>
+  <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
+    <tag k="name" v="d"/>
+  </node>
+  <node id="4" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="0.999820186412746">
+    <tag k="name" v="c"/>
+  </node>
+  <way id="5" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="motorway"/>
+    <tag k="oneway" v=""/>
+    <tag k="name" v="abd"/>
+  </way>
+  <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
+    <nd ref="2"/>
+    <nd ref="4"/>
+    <tag k="highway" v="motorway"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="name" v="bc"/>
+  </way>
+</osm>

--- a/tests/negative/94_not_a_oneway_link.osm
+++ b/tests/negative/94_not_a_oneway_link.osm
@@ -5,8 +5,9 @@
   </node>
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
-    <tag k="highway" v=""/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="highway" v="motorway_junction"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -26,7 +27,7 @@
     <nd ref="2"/>
     <nd ref="4"/>
     <tag k="highway" v="motorway_link"/>
-    <tag k="oneway" v="yes"/>
+    <tag k="oneway" v="no"/>
     <tag k="name" v="bc"/>
   </way>
 </osm>

--- a/tests/positive/157_reversed_way.osm
+++ b/tests/positive/157_reversed_way.osm
@@ -6,7 +6,8 @@
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
     <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -20,15 +21,13 @@
     <nd ref="3"/>
     <tag k="highway" v="motorway"/>
     <tag k="oneway" v=""/>
-    <tag k="destination:ref" v=""/>
     <tag k="name" v="abd"/>
   </way>
   <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
-    <nd ref="2"/>
     <nd ref="4"/>
+    <nd ref="2"/>
     <tag k="highway" v="motorway_link"/>
-    <tag k="oneway" v="yes"/>
-    <tag k="destination:ref" v="DestinationC"/>
-    <tag k="name" v="bc"/>
+    <tag k="oneway" v="-1"/>
+    <tag k="name" v="cb"/>
   </way>
 </osm>

--- a/tests/positive/8_successful_rewrite.osm
+++ b/tests/positive/8_successful_rewrite.osm
@@ -6,7 +6,8 @@
   <node id="2" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0007192543490164" lat="1.0">
     <tag k="name" v="b"/>
     <tag k="highway" v="motorway_junction"/>
-    <tag k="exit_to" v="ExitC"/>
+    <tag k="exit_to" v="A"/>
+    <tag k="ref" v="2"/>
   </node>
   <node id="3" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z" lon="1.0012586951107787" lat="1.0">
     <tag k="name" v="d"/>
@@ -20,7 +21,6 @@
     <nd ref="3"/>
     <tag k="highway" v="motorway"/>
     <tag k="oneway" v=""/>
-    <tag k="destination" v=""/>
     <tag k="name" v="abd"/>
   </way>
   <way id="6" version="1" uid="1" user="osrm" timestamp="2000-01-01T00:00:00Z">
@@ -28,7 +28,6 @@
     <nd ref="4"/>
     <tag k="highway" v="motorway_link"/>
     <tag k="oneway" v="yes"/>
-    <tag k="destination" v="DestinationC"/>
     <tag k="name" v="bc"/>
   </way>
 </osm>

--- a/tests/rewrite.feature
+++ b/tests/rewrite.feature
@@ -1,7 +1,4 @@
-Feature: Rewrites ExitTo Node Tags to Destination Way tags
-# `exit_to=` is tagged on nodes in combination with the `highway=motorway_junction` tag.
-# - http://wiki.openstreetmap.org/wiki/Key:exit_to
-# - https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_junction
+Feature: Tag Rewriter Tests
 
     Background:
         Given the profile "car"
@@ -16,8 +13,8 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    | motorway_junction | ExitC   |
+            | node | highway           | exit_to | ref |
+            | b    | motorway_junction | A       | 2   |
 
         And the ways
             | nodes | highway       | oneway |
@@ -38,8 +35,8 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to:left | exit_to:right |
-            | b    | motorway_junction | ExitC        | ExitD         |
+            | node | highway           | exit_to:left | exit_to:right | ref:left | ref:right |
+            | b    | motorway_junction | A            | B             |        2 |         3 |
 
         And the ways
             | nodes | highway       | oneway |
@@ -60,8 +57,8 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    |                   | ExitC   |
+            | node | highway | exit_to | ref |
+            | b    |         | A       |   2 |
 
         And the ways
             | nodes | highway       | oneway |
@@ -81,8 +78,8 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    | motorway_junction | ExitC   |
+            | node | highway           | exit_to | ref |
+            | b    | motorway_junction |       A |   2 |
 
         And the ways
             | nodes | highway       | oneway |
@@ -102,8 +99,8 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    | motorway_junction | ExitC   |
+            | node | highway           | exit_to | ref |
+            | b    | motorway_junction |      A  |   2 |
 
         And the ways
             | nodes | highway       | oneway |
@@ -115,7 +112,7 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             | a,c       | ab,bc,bc |
 
 
-    Scenario: Destination tag already present
+    Scenario: Tag already present
         Given the node map
             """
             a . . . b . . d .
@@ -123,19 +120,20 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    | motorway_junction | ExitC   |
+            | node | highway           | exit_to | ref |
+            | b    | motorway_junction |       A |   2 |
 
         And the ways
-            | nodes | highway       | oneway | destination  |
-            | abd   | motorway      |        |              |
-            | bc    | motorway_link | yes    | DestinationC |
+            | nodes | highway       | oneway | destination  | junction:ref |
+            | abd   | motorway      |        |              |              |
+            | bc    | motorway_link | yes    |            B |            2 |
 
        When I route I should get
             | waypoints | route    |
             | a,c       | ab,bc,bc |
 
-    Scenario: Destination ref tag already present
+
+    Scenario: Ref tag already present
         Given the node map
             """
             a . . . b . . d .
@@ -143,14 +141,15 @@ Feature: Rewrites ExitTo Node Tags to Destination Way tags
             """
 
        And the nodes
-            | node | highway           | exit_to |
-            | b    | motorway_junction | ExitC   |
+            | node | highway           | exit_to | ref |
+            | b    | motorway_junction |       A |   2 |
 
         And the ways
-            | nodes | highway       | oneway | destination:ref |
-            | abd   | motorway      |        |                 |
-            | bc    | motorway_link | yes    | DestinationC    |
+            | nodes | highway       | oneway | destination:ref | junction:ref |
+            | abd   | motorway      |        |                 |              |
+            | bc    | motorway_link | yes    |               B |            3 |
 
        When I route I should get
             | waypoints | route    |
             | a,c       | ab,bc,bc |
+


### PR DESCRIPTION
Re-writes `ref` node tags on `highway=motorway_junction` to `junction:ref` way tags on the adjacent ways when unambiguously possible.

Limitations are documented in the test below: we don't handle the `ref:left` and `ref:right` tags of which there are only a few hundreds on the planet.

In contrast to destination tags we always add a `junction:ref` way tag (except there is already a `junction:ref tag`) but we never check e.g. for `ref` tags already being present on the way. This is because our routing engine _only_ uses `junction:ref` way tags for exit numbers.

https://github.com/mapbox/rewrite-exit-destination-signage/blob/exit-numbers/tests/rewrite.feature

cc @willwhite 