### PR TITLE
Never re-writes on if :left and :right tag suffixes are present on the node, see #10

### DIFF
--- a/src/destinations.h
+++ b/src/destinations.h
@@ -37,6 +37,14 @@ struct DestinationsRewriter : osmium::handler::Handler {
       return;
 
     const auto *exitTo = node.get_value_by_key("exit_to");
+    const auto *exitToLeft = node.get_value_by_key("exit_to:left");
+    const auto *exitToRight = node.get_value_by_key("exit_to:right");
+
+    // There is an edge case where users tag not only `exit_to` but also
+    // `exit_to:left` and `exit_to:right`. In this case re-writing only
+    // the `exit_to` tag is always wrong - see #10. Bail out for now.
+    if (exitTo && (exitToLeft || exitToRight))
+      return;
 
     if (exitTo)
       destinations.insert({node.positive_id(), std::string{exitTo}});

--- a/src/exits.h
+++ b/src/exits.h
@@ -35,6 +35,14 @@ struct ExitsRewriter : osmium::handler::Handler {
       return;
 
     const auto *ref = node.get_value_by_key("ref");
+    const auto *refLeft = node.get_value_by_key("ref:left");
+    const auto *refRight = node.get_value_by_key("ref:right");
+
+    // There is an edge case where users tag not only `ref` but also
+    // `ref:left` and `ref:right`. In this case re-writing only
+    // the `ref` tag is always wrong - see #10. Bail out for now.
+    if (ref && (refLeft || refRight))
+      return;
 
     if (ref)
       exits.insert({node.positive_id(), std::string{ref}});


### PR DESCRIPTION
See discussion in #10.

Do not rewrite tags if the node _also_ has `:left` / `:right` tags.